### PR TITLE
Add option to enable/disable reporting of hosts

### DIFF
--- a/katello-attach-subscription
+++ b/katello-attach-subscription
@@ -27,6 +27,7 @@ require 'apipie-bindings'
   :pass      => 'changeme',
   :org       => 1,
   :search    => nil,
+  :reports   => false,
 }
 
 @options = {
@@ -169,6 +170,19 @@ def vdcupdate()
           puts " added"
         else
           puts " [noop] added"
+        end
+      end
+      # set foreman reporting to true/false
+      if api.has_resource?(:hosts)
+        if api.resource(:hosts).call(:show, {:id => system['host_id']})['enabled'] != @options[:reports]
+          if not @options[:noop]
+            api.resource(:hosts).call(:update, {:id => system['host_id'], :host => {:enabled => @options[:reports]}})
+            puts " foreman reporting set to #{@options[:reports]}"
+          else
+            puts " [noop] foreman reporting set to #{@options[:reports]}"
+          end
+        else
+          puts " foreman reporting already set to #{@options[:reports]}"
         end
       end
     end

--- a/katello-attach-subscription.yaml
+++ b/katello-attach-subscription.yaml
@@ -4,6 +4,7 @@
   :pass: changeme
   :uri: https://localhost
   :org: 1
+  :reports: false
 :subs:
   - hostname: esxi[0-9]\.example\.com
     registered_by: 85e65e06-a117-4e8e-8aa1-72cb1e00b930


### PR DESCRIPTION
Since Katello 3.0 hypervisors get added like normal hosts; means they show up as having not yet reported. This patch allows to disable that. They will show up as "hosts with alerts disabled"

I have not tested this against katello 2.x.

Greetings
Klaas
