### PR TITLE
Fix getting facts for hosts from the API

### DIFF
--- a/katello-attach-subscription
+++ b/katello-attach-subscription
@@ -1080,12 +1080,14 @@ def vdcupdate()
       if @options[:debug]
         puts " DEBUG: Checking the number of socket for #{sys["name"]}"
       end
+      # get the facts for the current host from a api call to fact_values
+      facts = @api.resource(:fact_values).action(:index).call(:organization_id => 1, :per_page => 100000, :search => "host = #{sys['name']}")
       # if the number of socket is setted, we can find the value from cpu::cpu_socket(s)
-      if sys.has_key?("facts") and sys["facts"].is_a?(Hash) and sys["facts"].has_key?("cpu::cpu_socket(s)")
+      if facts.has_key?('results') and facts['results'].is_a?(Hash) and facts['results'].has_key?(sys['name']) and facts['results'][sys['name']].is_a?(Hash) and facts['results'][sys['name']].has_key?("cpu::cpu_socket(s)")
         # if the field is present check if it's a valid entry or not, if not exit with error
-        if sys["facts"]["cpu::cpu_socket(s)"].to_i > 0
+        if facts['results'][sys['name']]['cpu::cpu_socket(s)'].to_i > 0
           # set sys_socket to the value of cpu::cpu_socket(s)
-          sys_socket = sys["facts"]["cpu::cpu_socket(s)"].to_i
+          sys_socket = facts['results'][sys['name']]['cpu::cpu_socket(s)'].to_i
           if @options[:debug]
             puts "   DEBUG: Setting sys_socket to #{sys_socket} for #{sys["name"]}"
           end

--- a/lib/katello_attach_subscription/fact_analyzer.rb
+++ b/lib/katello_attach_subscription/fact_analyzer.rb
@@ -7,6 +7,8 @@ module KatelloAttachSubscription
     UNKNOWN = 'Unknown'.freeze
 
     def self.system_type_from_facts(facts)
+      return unless facts.is_a?(Hash)
+
       if (not facts['virt::host_type'].nil? and facts['virt::host_type'] != 'Not Applicable') or
           (facts['virt::is_guest'] and facts['virt::is_guest'].to_s.downcase != 'false') or
           facts['virt::uuid']


### PR DESCRIPTION
Get the facts for a host with an own API call because the facts are not included in the API call to show the host. This will make it possible for KAS to determine the quantity of CPU sockets on a host and therefore make it possible to attach the correct quantity of entitlements of a subscription.

Tested with Satellite 6.5 and API Version 2

Fixes https://github.com/RedHatSatellite/katello-attach-subscription/issues/69