### PR TITLE
Add missing view_organizations permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The following permissions are required to run `katello-attach-subscription`:
 | Fact Value | view_facts|
 | Host | view_hosts, edit_hosts|
 | Subscription | view_subscriptions, attach_subscriptions, unattach_subscriptions|
-
+| Organization | view_organizations|
 
 ## Caveats
 


### PR DESCRIPTION
katello-attach-subscription leverages `/api/organizations/1/hosts?search=hypervisor%3Dtrue`
to get all hypervisor hosts. Therefore organization listing (view) is required.

Fixes #71 